### PR TITLE
python -m reposcore ... 최상위 디렉토리에서 실행하라는 내용 README에 추가 #310

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ make requirements
 아래는 `python -m reposcore -h` 또는 `python -m reposcore --help` 실행 결과를 붙여넣은 것이므로
 명령줄 관련 코드가 변경되면 아래 내용도 그에 맞게 수정해야 함.
 
+**⚠️ 반드시 저장소 최상위 디렉토리에서 실행해야 합니다. (python -m reposcore 명령은 상대 경로 기준으로 동작합니다.)**
+
+```bash
+python -m reposcore [OPTIONS]
+```
+
 ```
 usage: python -m reposcore [-h] owner/repo [--output dir_name] [--format {table,text,chart,all}]
 

--- a/template_README.md
+++ b/template_README.md
@@ -18,6 +18,12 @@ make requirements
 아래는 `python -m reposcore -h` 또는 `python -m reposcore --help` 실행 결과를 붙여넣은 것이므로
 명령줄 관련 코드가 변경되면 아래 내용도 그에 맞게 수정해야 함.
 
+**⚠️ 반드시 저장소 최상위 디렉토리에서 실행해야 합니다. (python -m reposcore 명령은 상대 경로 기준으로 동작합니다.)**
+
+```bash
+python -m reposcore [OPTIONS]
+```
+
 ```
 {{ usage }}
 ```


### PR DESCRIPTION
python -m reposcore ... 최상위 디렉토리에서 실행하라는 내용 README에 추가 https://github.com/oss2025hnu/reposcore-py/issues/310 에 대한 PR입니다.

Specify version (commit id).
a5b5853

변경사항
* README.md의 ## Usage 섹션에 python -m reposcore [OPTIONS] 형태의 CLI 명령어 예시 추가
* python -m reposcore -h 결과를 반영한 명령어 옵션 설명 템플릿 추가 ({{ usage }} 포함)
* 저장소 최상위 경로에서 명령어를 실행해야 한다는 안내 문구 삽입

Describe alternatives you've considered

* README.md의 사용법을 단순히 한 줄로 요약하는 방식도 고려했으나,
사용자 입장에서 실제 명령어 실행 예시(python -m reposcore [OPTIONS])와 함께 -h 결과를 함께 보여주는 것이 더 직관적이라 판단했습니다.
* GitHub Actions 또는 위키 문서로 따로 분리하여 설명하는 방법도 있었지만,
README.md가 가장 접근성이 높아 이곳에 포함하는 방향을 택했습니다.

